### PR TITLE
Add missing dependencies to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,9 @@ dependencies:
   - pillow_heif
   - wandb
   - ipdb
+  - opencv-python
+  - matplotlib
+  - point_cloud_utils
   - pip:
     - submodules/diff-gaussian-rasterization_igs
     - submodules/simple-knn


### PR DESCRIPTION
The environment.yml is missing the following required dependencies for the distortion_curve.py script:
- matplotlib
- point_cloud_utils
- opencv-python